### PR TITLE
Source code diffing, logging, improved project structure

### DIFF
--- a/_config.example.php
+++ b/_config.example.php
@@ -24,3 +24,4 @@ define('LOGIN_USERNAME_ID', 'MemberLoginForm_LoginForm_Email');
 define('LOGIN_PASSWORD_ID', 'MemberLoginForm_LoginForm_Password');
 define('LOGIN_SUBMIT_ID', 'MemberLoginForm_LoginForm_action_dologin');
 
+define('ROOT_DIR', __DIR__);

--- a/_config.example.php
+++ b/_config.example.php
@@ -7,7 +7,7 @@ define('SCREENSHOT_BASELINE', true);
 define('SCREENSHOT_BRANCH', true);
 define('CREATE_RESULTS', true);
 
-define('SHOW_DEBUG', false);
+define('LOG_LEVEL', Monolog\Logger::INFO);
 
 define('PATHS', serialize([
     '/',

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,13 @@
   ],
   "require": {
     "php": ">=5.6",
-    "facebook/webdriver": "1.5.0"
+    "facebook/webdriver": "1.5.0",
+    "monolog/monolog": "^1.23"
+  },
+  "autoload": {
+    "psr-4": {
+      "Roboshot\\": "src/Roboshot"
+    }
   },
   "minimum-stability": "dev",
   "prefer-stable": true

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4ad96f3d0c687059c3ea91f1c634494a",
+    "content-hash": "9679b07dd129819779bfd09af8668926",
     "packages": [
         {
             "name": "facebook/webdriver",
@@ -60,6 +60,131 @@
                 "webdriver"
             ],
             "time": "2017-11-15T11:08:09+00:00"
+        },
+        {
+            "name": "monolog/monolog",
+            "version": "1.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/monolog.git",
+                "reference": "fd8c787753b3a2ad11bc60c063cff1358a32a3b4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/fd8c787753b3a2ad11bc60c063cff1358a32a3b4",
+                "reference": "fd8c787753b3a2ad11bc60c063cff1358a32a3b4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "psr/log": "~1.0"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0.0"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                "doctrine/couchdb": "~1.0@dev",
+                "graylog2/gelf-php": "~1.0",
+                "jakub-onderka/php-parallel-lint": "0.9",
+                "php-amqplib/php-amqplib": "~2.4",
+                "php-console/php-console": "^3.1.3",
+                "phpunit/phpunit": "~4.5",
+                "phpunit/phpunit-mock-objects": "2.3.0",
+                "ruflin/elastica": ">=0.90 <3.0",
+                "sentry/sentry": "^0.13",
+                "swiftmailer/swiftmailer": "^5.3|^6.0"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                "ext-mongo": "Allow sending log messages to a MongoDB server",
+                "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
+                "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                "php-console/php-console": "Allow sending log messages to Google Chrome",
+                "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                "sentry/sentry": "Allow sending log messages to a Sentry server"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Monolog\\": "src/Monolog"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+            "homepage": "http://github.com/Seldaek/monolog",
+            "keywords": [
+                "log",
+                "logging",
+                "psr-3"
+            ],
+            "time": "2017-06-19T01:22:40+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "time": "2016-10-10T12:19:37+00:00"
         },
         {
             "name": "symfony/process",

--- a/go.php
+++ b/go.php
@@ -14,16 +14,14 @@
 
 */
 
-namespace Roboshot;
-
-require_once __DIR__ . '/vendor/autoload.php';
+require_once 'vendor/autoload.php';
+require_once '_config.php';
 
 use Facebook\WebDriver\Chrome\ChromeDriverService;
+use Monolog\Handler\StreamHandler;
 
-require_once 'BaseClass.php';
-require_once 'BrowserPilot.php';
-require_once 'ImageMaker.php';
-require_once 'ResultsMaker.php';
+// Output our logs to the console
+\Roboshot\Logger::get()->pushHandler(new StreamHandler('php://stdout', LOG_LEVEL));
 
 # === SCRIPT ============
 ini_set('memory_limit', '1024M');
@@ -34,35 +32,14 @@ if (isset($_SERVER['OS']) && $_SERVER['OS'] == 'Windows_NT') {
     putenv("$var=webdriver/mac64/chromedriver 3");
 }
 
-// logging functions
-function log($str, $trace = null) {
-    if (!$trace) {
-        $trace = debug_backtrace()[0];
-    }
-    $line = $trace['line'];
-    preg_match('%/([A-Z\.a-z]+)$%', $trace['file'], $match);
-    $file = $match[1];
-    $fileline = "$file:$line";
-    $fileline = str_pad($fileline, 20, ' ', STR_PAD_RIGHT);
-    echo "$fileline -- $str\n";
-}
-
-function debug($str) {
-    if (SHOW_DEBUG) {
-        log($str, debug_backtrace()[0]);
-    }
-}
-
 // create directories
-if (!file_exists("screenshots")) {
-    mkdir("screenshots");
+if (!file_exists(ROOT_DIR."/screenshots")) {
+    mkdir(ROOT_DIR."/screenshots");
 }
-if (!file_exists("screenshots/results")) {
-    mkdir("screenshots/results");
+if (!file_exists(ROOT_DIR."/screenshots/results")) {
+    mkdir(ROOT_DIR."/screenshots/results");
 }
 
-// read config
-require_once '_config.php';
 $baselineDomain = rtrim(BASELINE_DOMAIN, '/');
 $branchDomain = rtrim(BRANCH_DOMAIN, '/');
 $screenshotBaseline = SCREENSHOT_BASELINE;
@@ -71,15 +48,16 @@ $paths = unserialize(PATHS);
 $createResults = CREATE_RESULTS;
 
 // create objects
-$browserPilot = new BrowserPilot();
-$imageMaker = new ImageMaker();
-$resultsMaker = new ResultsMaker();
+$browserPilot = new Roboshot\BrowserPilot();
+$imageMaker = new Roboshot\ImageMaker();
+$resultsMaker = new Roboshot\ResultsMaker();
 
 // take screenshots
 if ($screenshotBaseline || $screenshotBranch) {
     $driver = $browserPilot->createDriver();
     $imageMaker->setDriver($driver);
     $imageMaker->setBrowserPilot($browserPilot);
+
     foreach ([$baselineDomain, $branchDomain] as $domain) {
         if (!$screenshotBaseline && $domain == $baselineDomain) {
             continue;

--- a/src/Roboshot/BaseClass.php
+++ b/src/Roboshot/BaseClass.php
@@ -3,6 +3,7 @@
 namespace Roboshot;
 
 use Facebook\WebDriver\Chrome\ChromeDriver;
+use Monolog\Logger;
 
 class BaseClass
 {
@@ -16,6 +17,11 @@ class BaseClass
      * @var string
      */
     protected $domain;
+
+    /**
+     * @var Logger
+     */
+    protected $log;
 
     /**
      * @param ChromeDriver $driver
@@ -47,6 +53,23 @@ class BaseClass
     function getDomain()
     {
         return $this->domain;
+    }
+
+    /**
+     * @return Logger
+     */
+    public function getLogger() {
+        return $this->log;
+    }
+
+    /**
+     * @param Logger $log
+     * @return BaseClass
+     */
+    public function setLogger($log) {
+        $this->log = $log;
+
+        return $this;
     }
 
     /**

--- a/src/Roboshot/BrowserPilot.php
+++ b/src/Roboshot/BrowserPilot.php
@@ -32,7 +32,8 @@ class BrowserPilot extends BaseClass
      */
     function get($path)
     {
-        log('Navigating to ' . $this->domain . $path);
+        Logger::get()->info('Navigating to ' . $this->domain . $path);
+
         $this->driver->get($this->domain . $path);
         $this->waitUntilPageLoaded();
     }
@@ -76,7 +77,8 @@ EOT
                 return;
             }
         }
-        log("! Page did not fully load after 30 seconds");
+
+        Logger::get()->warn("Page did not fully load after 30 seconds");
     }
 
     /**
@@ -107,6 +109,7 @@ EOT
      */
     function close()
     {
+        Logger::get()->debug('Closing the browser');
         $this->driver->close();
     }
 

--- a/src/Roboshot/Logger.php
+++ b/src/Roboshot/Logger.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Roboshot;
+
+use Monolog;
+
+/**
+ * A centralized logging class for your logging needs
+ * @package Roboshot
+ */
+class Logger {
+    /**
+     * @var Monolog\Logger
+     */
+    protected static $logger;
+
+    public function __construct()
+    {
+        $this->createLogger();
+    }
+
+    /**
+     * Returns the current instance of the Monolog logfer
+     * @returns Monolog\Logger
+     */
+    public static function get()
+    {
+        if (!self::$logger) {
+            self::createLogger();
+        }
+
+        return self::$logger;
+    }
+
+    /**
+     * Creates a Monolog instance
+     */
+    public static function createLogger() {
+        self::$logger = new Monolog\Logger(__NAMESPACE__);
+    }
+}

--- a/src/Roboshot/ResultsMaker.php
+++ b/src/Roboshot/ResultsMaker.php
@@ -18,25 +18,22 @@ class ResultsMaker extends BaseClass
     public function createResults($baselineDomain, $branchDomain)
     {
         $resultsDir = $this->createResultsDir($branchDomain);
-        $imageMaker = new ImageMaker();
         list($baselineDir) = $this->getDirAndFilename($baselineDomain, '/');
-        $baselineFiles = scandir(getcwd() . "/screenshots/$baselineDir");
+        $baselineFiles = scandir(ROOT_DIR . "/screenshots/$baselineDir");
         $imageHtmls = [];
+
         foreach($baselineFiles as $filename) {
-            if (strtolower(pathinfo($filename, PATHINFO_EXTENSION)) != 'png') {
-                continue;
+            switch(strtolower(pathinfo($filename, PATHINFO_EXTENSION))) {
+                case 'png':
+                    $imageHtmls[] = $this->handleImageResult($filename, $baselineDomain, $branchDomain);
+                    break;
+
+                case 'html':
+                    $this->handleHTMLResult($filename, $baselineDomain, $branchDomain);
+                    break;
             }
-            $path = '/' . str_replace('|', '/', $filename);
-            $path = str_replace('.png', '', $path);
-            $montageFilename = $imageMaker->createDiffAndMontageImages($filename, $baselineDomain, $branchDomain);
-            $thumbFilename = $imageMaker->getThumbPath($montageFilename);
-            $imageHtml = file_get_contents('templates/screenshot.html');
-            $imageHtml = str_replace('%src%', $montageFilename, $imageHtml);
-            $imageHtml = str_replace('%thumbsrc%', $thumbFilename, $imageHtml);
-            $imageHtml = str_replace('%filename%', $montageFilename, $imageHtml);
-            $imageHtml = str_replace('%path%', $path, $imageHtml);
-            $imageHtmls[] = $imageHtml;
         }
+
         // reverse sort array so most different diff's are first
         rsort($imageHtmls);
         $html = file_get_contents('templates/results.html');
@@ -44,6 +41,27 @@ class ResultsMaker extends BaseClass
         file_put_contents("$resultsDir/results.html", $html);
         copy('templates/styles.css', "$resultsDir/styles.css");
         copy('templates/script.js', "$resultsDir/script.js");
+    }
+
+    protected function handleHTMLResult($filename, $baselineDomain, $branchDomain) {
+        $sourceDiff = new SourceDiff();
+        $sourceDiff->createDiff($filename, $baselineDomain, $branchDomain);
+    }
+
+    protected function handleImageResult($filename, $baselineDomain, $branchDomain) {
+        $imageMaker = new ImageMaker();
+
+        $path = '/' . str_replace('|', '/', $filename);
+        $path = str_replace('.png', '', $path);
+        $montageFilename = $imageMaker->createDiffAndMontageImages($filename, $baselineDomain, $branchDomain);
+        $thumbFilename = $imageMaker->getThumbPath($montageFilename);
+        $imageHtml = file_get_contents('templates/screenshot.html');
+        $imageHtml = str_replace('%src%', $montageFilename, $imageHtml);
+        $imageHtml = str_replace('%thumbsrc%', $thumbFilename, $imageHtml);
+        $imageHtml = str_replace('%filename%', $montageFilename, $imageHtml);
+        $imageHtml = str_replace('%path%', $path, $imageHtml);
+
+        return $imageHtml;
     }
 
     /**
@@ -56,7 +74,7 @@ class ResultsMaker extends BaseClass
     protected function createResultsDir($branchDomain)
     {
         list($branchDir) = $this->getDirAndFilename($branchDomain, '/');
-        $resultsDir = getcwd() . "/screenshots/results/$branchDir";
+        $resultsDir = ROOT_DIR . "/screenshots/results/$branchDir";
         if (!file_exists($resultsDir)) {
             mkdir($resultsDir);
         }

--- a/src/Roboshot/SourceDiff.php
+++ b/src/Roboshot/SourceDiff.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Roboshot;
+
+/**
+ * Computes the difference between two files
+ * @package Roboshot
+ */
+class SourceDiff extends BaseClass
+{
+    /**
+     * Creates a diff file
+     * @param $filename
+     * @param $baselineDomain
+     * @param $branchDomain
+     */
+    public function createDiff($filename, $baselineDomain, $branchDomain) {
+        if(\function_exists('xdiff_file_diff')) {
+            list($baselineDir) = $this->getDirAndFilename($baselineDomain, '/');
+            list($branchDir) = $this->getDirAndFilename($branchDomain, '/');
+
+            $baselinePath = ROOT_DIR."/screenshots/$baselineDir/$filename";
+            $branchPath = ROOT_DIR."/screenshots/$branchDir/$filename";
+            $filename = \str_replace('/', '', $filename);
+
+            $diffFolder = ROOT_DIR. "/screenshots/results/$branchDir/diffs/";
+
+            if (!\file_exists($diffFolder)) {
+                \mkdir($diffFolder);
+            }
+
+            $fileName = $diffFolder.str_replace('.png', '', $filename).".diff";
+
+            // Perform the file diff
+            \xdiff_file_diff($baselinePath, $branchPath, $fileName);
+        } else {
+            Logger::get()->debug('xdiff_file_diff not present, skipping the file diff');
+        }
+    }
+}


### PR DESCRIPTION
## Source code diffing
As outlined in #3, when `xdiff` is installed a diff file of the source code will be generated. This will help to speed up investigating changes where the markup of the page might've changed (such as Userform template changes)

## PSR-4
Classes are now autoloaded using Composer to simplify things when additional classes are added. Because of this, a new `ROOT_DIR` constant is now used for path references.

## Logging
[Monolog](https://github.com/Seldaek/monolog) has been added to provide a single easy-to-use logging interface. By default this will log to stdout, and the log level can be configured in the _config.php file. 

Example log entries when set to DEBUG:
```
[2018-06-09 21:47:17] Roboshot.INFO: Navigating to http://fieldtriq.test/ [] []
[2018-06-09 21:47:21] Roboshot.INFO: Taking screenshot of http://fieldtriq.test/ [] []
[2018-06-09 21:47:21] Roboshot.DEBUG: documentHeight = 3270 [] []
[2018-06-09 21:47:21] Roboshot.DEBUG: viewportHeight = 714 [] []
[2018-06-09 21:47:23] Roboshot.DEBUG: imageWidth = 2880 [] []
[2018-06-09 21:47:23] Roboshot.DEBUG: imageHeight = 1428 [] []
[2018-06-09 21:47:23] Roboshot.DEBUG: imageRatio = 2 [] []
```